### PR TITLE
fix: use Web Crypto API for session encryption (Cloudflare Workers compat)

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -96,7 +96,7 @@ export async function GET(request: NextRequest) {
       return createErrorRedirect(request, 'invalid_user_data');
     }
 
-    const serializedSession = encodeAuthSession({
+    const serializedSession = await encodeAuthSession({
       accessToken: tokenData.access_token,
       user: {
         login: userData.login,

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -5,7 +5,7 @@ import {
 } from '@/lib/auth-session';
 
 export async function GET(request: NextRequest) {
-  const session = getAuthSessionFromRequest(request);
+  const session = await getAuthSessionFromRequest(request);
   const oauthEnabled = hasGithubOAuthConfig();
 
   if (!session) {

--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -174,7 +174,7 @@ export async function GET(request: NextRequest) {
 
   const username = requestedUsername.toLowerCase();
 
-  const authSession = getAuthSessionFromRequest(request);
+  const authSession = await getAuthSessionFromRequest(request);
   const authSessionLogin = authSession?.user.login.toLowerCase() ?? null;
   const token = authSession?.accessToken ?? process.env.GITHUB_TOKEN;
   const shouldBypassCache = Boolean(authSession);

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,9 +1,3 @@
-import {
-  createCipheriv,
-  createDecipheriv,
-  createHash,
-  randomBytes,
-} from 'node:crypto';
 import type { NextRequest } from 'next/server';
 
 const SESSION_VERSION = 1;
@@ -11,6 +5,9 @@ const SESSION_COOKIE_NAME = 'github_oauth_session';
 const STATE_COOKIE_NAME = 'github_oauth_state';
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
 const STATE_MAX_AGE_SECONDS = 60 * 10;
+
+// AES-GCM auth tag length in bytes
+const TAG_LENGTH = 16;
 
 interface SessionUser {
   login: string;
@@ -32,6 +29,28 @@ export interface AuthSession {
 export { SESSION_COOKIE_NAME, SESSION_MAX_AGE_SECONDS };
 export { STATE_COOKIE_NAME, STATE_MAX_AGE_SECONDS };
 
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(str: string): Uint8Array {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ── Public utilities ─────────────────────────────────────────────────
+
 export function hasGithubOAuthConfig() {
   return Boolean(
     process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET,
@@ -39,27 +58,44 @@ export function hasGithubOAuthConfig() {
 }
 
 export function createOAuthState() {
-  return randomBytes(16).toString('base64url');
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return toBase64Url(bytes);
 }
 
-function getSessionKey() {
+// ── Session key ──────────────────────────────────────────────────────
+
+async function getSessionKey(): Promise<CryptoKey | null> {
   const secret = process.env.GITHUB_CLIENT_SECRET;
   if (!secret) {
     return null;
   }
 
-  return createHash('sha256').update(secret).digest();
+  const encoded = new TextEncoder().encode(secret);
+  const hash = await crypto.subtle.digest('SHA-256', encoded);
+
+  return crypto.subtle.importKey(
+    'raw',
+    hash,
+    { name: 'AES-GCM' },
+    false,
+    ['encrypt', 'decrypt'],
+  );
 }
 
-export function encodeAuthSession(session: AuthSession) {
-  const key = getSessionKey();
+// ── Encode / Decode ──────────────────────────────────────────────────
+
+export async function encodeAuthSession(
+  session: AuthSession,
+): Promise<string | null> {
+  const key = await getSessionKey();
   if (!key) {
     return null;
   }
 
-  // AES-GCM is standardized with a 96-bit (12-byte) nonce/IV.
-  const iv = randomBytes(12);
-  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const iv = new Uint8Array(12);
+  crypto.getRandomValues(iv);
+
   const payload: StoredAuthSession = {
     version: SESSION_VERSION,
     accessToken: session.accessToken,
@@ -67,21 +103,27 @@ export function encodeAuthSession(session: AuthSession) {
     expiresAt: Date.now() + SESSION_MAX_AGE_SECONDS * 1000,
   };
 
-  const encrypted = Buffer.concat([
-    cipher.update(JSON.stringify(payload), 'utf8'),
-    cipher.final(),
-  ]);
-  const tag = cipher.getAuthTag();
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload));
 
-  return `${iv.toString('base64url')}.${tag.toString('base64url')}.${encrypted.toString('base64url')}`;
+  // Web Crypto AES-GCM returns ciphertext || authTag (tag is last 16 bytes)
+  const combined = new Uint8Array(
+    await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext),
+  );
+
+  const encrypted = combined.slice(0, combined.length - TAG_LENGTH);
+  const tag = combined.slice(combined.length - TAG_LENGTH);
+
+  return `${toBase64Url(iv)}.${toBase64Url(tag)}.${toBase64Url(encrypted)}`;
 }
 
-export function decodeAuthSession(value: string | undefined) {
+export async function decodeAuthSession(
+  value: string | undefined,
+): Promise<AuthSession | null> {
   if (!value) {
     return null;
   }
 
-  const key = getSessionKey();
+  const key = await getSessionKey();
   if (!key) {
     return null;
   }
@@ -94,19 +136,24 @@ export function decodeAuthSession(value: string | undefined) {
   const [ivPart, tagPart, encryptedPart] = parts;
 
   try {
-    const iv = Buffer.from(ivPart, 'base64url');
-    const tag = Buffer.from(tagPart, 'base64url');
-    const encrypted = Buffer.from(encryptedPart, 'base64url');
+    const iv = fromBase64Url(ivPart);
+    const tag = fromBase64Url(tagPart);
+    const encrypted = fromBase64Url(encryptedPart);
 
-    const decipher = createDecipheriv('aes-256-gcm', key, iv);
-    decipher.setAuthTag(tag);
+    // Web Crypto expects ciphertext || authTag concatenated
+    const combined = new Uint8Array(encrypted.length + tag.length);
+    combined.set(encrypted);
+    combined.set(tag, encrypted.length);
 
-    const decrypted = Buffer.concat([
-      decipher.update(encrypted),
-      decipher.final(),
-    ]).toString('utf8');
+    const decrypted = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      combined,
+    );
 
-    const session = JSON.parse(decrypted) as StoredAuthSession;
+    const session = JSON.parse(
+      new TextDecoder().decode(decrypted),
+    ) as StoredAuthSession;
 
     if (
       session.version !== SESSION_VERSION ||
@@ -124,6 +171,8 @@ export function decodeAuthSession(value: string | undefined) {
   }
 }
 
-export function getAuthSessionFromRequest(request: NextRequest) {
+export async function getAuthSessionFromRequest(
+  request: NextRequest,
+): Promise<AuthSession | null> {
   return decodeAuthSession(request.cookies.get(SESSION_COOKIE_NAME)?.value);
 }

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -36,11 +36,20 @@ function toBase64Url(bytes: Uint8Array): string {
   for (const byte of bytes) {
     binary += String.fromCharCode(byte);
   }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
 }
 
-function fromBase64Url(str: string): Uint8Array {
-  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+function fromBase64Url(str: string): Uint8Array<ArrayBuffer> {
+  const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - (base64.length % 4)) % 4;
+  if (paddingLength === 3) {
+    throw new Error('Invalid base64url string');
+  }
+
+  const padded = `${base64}${'='.repeat(paddingLength)}`;
   const binary = atob(padded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
@@ -74,13 +83,10 @@ async function getSessionKey(): Promise<CryptoKey | null> {
   const encoded = new TextEncoder().encode(secret);
   const hash = await crypto.subtle.digest('SHA-256', encoded);
 
-  return crypto.subtle.importKey(
-    'raw',
-    hash,
-    { name: 'AES-GCM' },
-    false,
-    ['encrypt', 'decrypt'],
-  );
+  return crypto.subtle.importKey('raw', hash, { name: 'AES-GCM' }, false, [
+    'encrypt',
+    'decrypt',
+  ]);
 }
 
 // ── Encode / Decode ──────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`auth-session.ts` imports from `node:crypto` (`createCipheriv`, `createDecipheriv`, `createHash`, `randomBytes`). Cloudflare Workers uses the **Web Crypto API**, not Node.js crypto. While `nodejs_compat` is enabled in `wrangler.jsonc`, the `node:crypto` module is not fully supported and will likely fail at runtime for AES-GCM operations.

## Solution

Rewrites `auth-session.ts` to use the standard Web Crypto API:

| Node.js crypto | Web Crypto replacement |
|---|---|
| `randomBytes(n)` | `crypto.getRandomValues(new Uint8Array(n))` |
| `createHash('sha256').update(s).digest()` | `crypto.subtle.digest('SHA-256', data)` |
| `createCipheriv('aes-256-gcm', key, iv)` | `crypto.subtle.encrypt({name: 'AES-GCM', iv}, key, data)` |
| `createDecipheriv('aes-256-gcm', key, iv)` | `crypto.subtle.decrypt({name: 'AES-GCM', iv}, key, data)` |
| `Buffer.from(..., 'base64url')` | Custom `toBase64Url` / `fromBase64Url` helpers |

Since Web Crypto operations return Promises, `encodeAuthSession`, `decodeAuthSession`, and `getAuthSessionFromRequest` are now `async`. All three route handlers that call them are updated with `await`.

## Cookie format

The cookie format stays identical (`iv.tag.ciphertext` as base64url, dot-separated) so no existing sessions are affected.

## Files changed

- `src/lib/auth-session.ts` — full rewrite to Web Crypto API
- `src/app/api/auth/callback/route.ts` — `await encodeAuthSession(...)`
- `src/app/api/auth/session/route.ts` — `await getAuthSessionFromRequest(...)`
- `src/app/api/github/route.ts` — `await getAuthSessionFromRequest(...)`