### PR TITLE
fix: restore GitHub sign-in button dark mode styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-all",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -278,7 +278,13 @@ body {
 /* ── GitHub sign-in button ──────────────────────────────────────────
    Dark mode:  solid dark button, white text & mark (standard GitHub style)
    Light mode: soft outlined button, dark text & mark (less heavy on white)
+
+   The default (.gh-sign-in-btn) is dark since :root defaults to dark.
+   Light styles only apply via explicit [data-theme='light'] or via the
+   prefers-color-scheme media query when no manual theme is set.
    ──────────────────────────────────────────────────────────────────── */
+
+/* Base / dark (matches :root default) */
 .gh-sign-in-btn {
   background-color: #24292f;
   color: #ffffff;
@@ -286,13 +292,21 @@ body {
   text-decoration: none;
 }
 
-[data-theme='light'] .gh-sign-in-btn,
-:root:not([data-theme]) .gh-sign-in-btn {
+/* Explicit dark override (redundant but defensive) */
+[data-theme='dark'] .gh-sign-in-btn {
+  background-color: #24292f;
+  color: #ffffff;
+  border: 1px solid #30363d;
+}
+
+/* Explicit light override */
+[data-theme='light'] .gh-sign-in-btn {
   background-color: #f6f8fa;
   color: #24292f;
   border: 1px solid #d0d7de;
 }
 
+/* System preference light (only when no manual theme is set) */
 @media (prefers-color-scheme: light) {
   :root:not([data-theme]) .gh-sign-in-btn {
     background-color: #f6f8fa;


### PR DESCRIPTION
## Problem

The previous commit added `:root:not([data-theme]) .gh-sign-in-btn` as a standalone rule outside the media query. Since no `data-theme` attribute is set by default (dark is the `:root` default), this selector matched in dark mode and applied the light button styles everywhere.

## Fix

Removed the standalone `:root:not([data-theme])` selector from outside the media query. Light button styles now only apply via:
- `[data-theme='light']` — explicit light mode toggle
- `@media (prefers-color-scheme: light)` with `:root:not([data-theme])` — system preference when no manual choice is set

Added an explicit `[data-theme='dark']` rule as a defensive measure.

## Result

- **Dark mode** (default or explicit): solid `#24292f` background, white text
- **Light mode** (explicit or system): soft `#f6f8fa` background, dark text, subtle border