### PR TITLE
feat: show app version subtly in footer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from 'next';
+import { version } from './package.json';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  env: {
+    // Exposed at build time so the footer can display the current app version.
+    // Sourced from package.json so it stays in sync with every release.
+    NEXT_PUBLIC_APP_VERSION: version,
+  },
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-all",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-all",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dependencies": {
         "next": "^15.3.0",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-all",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -263,7 +263,10 @@ export default function Home() {
           </a>
         </p>
         {process.env.NEXT_PUBLIC_APP_VERSION && (
-          <p className="text-[10px] mt-1" style={{ color: 'var(--text-muted)' }}>
+          <p
+            className="text-[10px] mt-1"
+            style={{ color: 'var(--text-muted)' }}
+          >
             v{process.env.NEXT_PUBLIC_APP_VERSION}
           </p>
         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -262,6 +262,11 @@ export default function Home() {
             Toastbyte Studios
           </a>
         </p>
+        {process.env.NEXT_PUBLIC_APP_VERSION && (
+          <p className="text-[10px] mt-1" style={{ color: 'var(--text-muted)' }}>
+            v{process.env.NEXT_PUBLIC_APP_VERSION}
+          </p>
+        )}
       </footer>
     </>
   );


### PR DESCRIPTION
## Summary

Adds a subtle app-version display to the footer and bumps the version to `1.7.0`.

The version is sourced from `package.json` at build time (exposed as `NEXT_PUBLIC_APP_VERSION` via `next.config.ts`), so it stays in sync with every release automatically — no hardcoded string to maintain.

## Changes

- **`next.config.ts`** — import `version` from `package.json` and expose it as `NEXT_PUBLIC_APP_VERSION` through the `env` config.
- **`src/app/page.tsx`** — render `v{version}` beneath the existing "Built by Toastbyte Studios" line in muted 10px text. Guarded so it renders nothing if the env var is ever absent.
- **`package.json`** — bump `1.6.1` → `1.7.0`.

## Notes

- I used a **minor** bump (`1.7.0`) since this adds a small user-facing feature. If you'd rather treat it as a patch (`1.6.2`), just retag `package.json` — the footer will follow whatever the version is.
- Styling: `text-[10px]` + `var(--text-muted)`, which keeps it legible in both light/dark themes (the muted token already meets the contrast minimum) while staying unobtrusive.
- Build-time `env` injection works for both server and client components, so this is robust if the footer ever moves into a client component.

Closes the "show current version subtly in the footer" idea.